### PR TITLE
PLATUI-3556 remove pega feature flag and test

### DIFF
--- a/app/uk/gov/hmrc/helpfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/helpfrontend/config/AppConfig.scala
@@ -35,5 +35,4 @@ class AppConfig @Inject() (config: Configuration, trackingConsentConfig: Trackin
   lazy val cookieSettingsUrl: String =
     s"$trackingConsentHost$cookieSettingsPath"
 
-  lazy val showPegaContent: Boolean = config.getOptional[Boolean]("flags.show-pega-content").getOrElse(false)
 }

--- a/app/uk/gov/hmrc/helpfrontend/views/CookiesPage.scala.html
+++ b/app/uk/gov/hmrc/helpfrontend/views/CookiesPage.scala.html
@@ -140,7 +140,6 @@
     cookieIds = Seq("js_detection")
   )
 
-  @if(appConfig.showPegaContent) {
     <h3 class="govuk-heading-m" id="cookies-pega-heading">@messages("help.cookies.how_used.pega.heading")</h3>
     <p class="govuk-body" id="cookies-pega-paragraph-1">@messages("help.cookies.how_used.pega.info.1")</p>
     <ul class="govuk-list govuk-list--bullet" id="cookies-pega-bullet">
@@ -154,7 +153,6 @@
         text = messages("help.cookies.how_used.pega.link.text")
       ))@messages("general.fullstop")
     </p>
-  }
 
   <h3 class="govuk-heading-m" id="cookies-tracking-consent-settings-heading">@messages("help.cookies.settings.heading")</h3>
   <p class="govuk-body" id="cookies-tracking-consent-settings-paragraph">

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -63,7 +63,3 @@ urls {
   accessibility-statement = "https://www.gov.uk/help/accessibility-statement"
   help = "https://www.gov.uk/help"
 }
-
-flags {
-  show-pega-content = false
-}

--- a/test/unit/views/CookiesSpec.scala
+++ b/test/unit/views/CookiesSpec.scala
@@ -34,8 +34,8 @@ class CookiesSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite wit
   override def fakeApplication(): Application =
     new GuiceApplicationBuilder()
       .configure(
-        "metrics.jvm"             -> false,
-        "metrics.enabled"         -> false
+        "metrics.jvm"     -> false,
+        "metrics.enabled" -> false
       )
       .build()
 

--- a/test/unit/views/CookiesSpec.scala
+++ b/test/unit/views/CookiesSpec.scala
@@ -35,8 +35,7 @@ class CookiesSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite wit
     new GuiceApplicationBuilder()
       .configure(
         "metrics.jvm"             -> false,
-        "metrics.enabled"         -> false,
-        "flags.show-pega-content" -> true
+        "metrics.enabled"         -> false
       )
       .build()
 
@@ -359,24 +358,6 @@ class CookiesSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite wit
         val link = paragraph.first().child(0)
         link.attr("href") mustBe "https://account.hmrc.gov.uk/debt/cookies"
         link.text mustBe "Find out more about cookies on Pega Services (opens in new tab)"
-      }
-
-      "not be displayed if feature flag is set to false" in new Fixture {
-        def appWithFlag(): Application =
-          new GuiceApplicationBuilder()
-            .configure(
-              "metrics.jvm"             -> false,
-              "metrics.enabled"         -> false,
-              "flags.show-pega-content" -> false
-            )
-            .build()
-
-        val configWithFlag: AppConfig           = appWithFlag().injector.instanceOf[AppConfig]
-        val cookiesPageWithFlag: CookiesPage    = appWithFlag().injector.instanceOf[CookiesPage]
-        val viewWithFlag: HtmlFormat.Appendable =
-          cookiesPageWithFlag()(fakeRequest, messagesApi.preferred(fakeRequest), configWithFlag)
-
-        viewWithFlag.select("#cookies-pega-heading").size() mustBe 0
       }
     }
 


### PR DESCRIPTION
# Purpose of PR
- To remove the pega feature flag, as the pega cookie consent content has gone live