### PR TITLE
PLATUI-3936 bump dependencies and suppress warns

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ lazy val microservice = Project(appName, file("."))
       "uk.gov.hmrc.hmrcfrontend.views.html.components.*",
       "uk.gov.hmrc.hmrcfrontend.views.html.helpers.*"
     ),
+    scalacOptions += "-Wconf:src=views/.*:s",
     scalacOptions += "-Wconf:src=routes/.*:s",
     scalacOptions += "-Wconf:msg=unused-imports&src=html/.*:s",
     Assets / pipelineStages := Seq(gzip),

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,8 +2,8 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.18.0"
-  private val frontendVersion  = "12.8.0"
+  private val bootstrapVersion = "9.19.0"
+  private val frontendVersion  = "12.10.0"
   private val playVersion      = "play-30"
 
   val compile = Seq(


### PR DESCRIPTION
# Purpose of PR
- Bump play-frontend-hmrc and bootstrap-frontend dependencies
- Suppress false positive warns on unused imports where it's actually a twirl comment: `@*` 