### PR TITLE
PLATUI-4272: allow display using service navigation

### DIFF
--- a/app/uk/gov/hmrc/helpfrontend/controllers/HelpController.scala
+++ b/app/uk/gov/hmrc/helpfrontend/controllers/HelpController.scala
@@ -21,6 +21,7 @@ import play.api.mvc.*
 import play.api.i18n.Lang
 import uk.gov.hmrc.helpfrontend.config.AppConfig
 import uk.gov.hmrc.helpfrontend.views.html.*
+import uk.gov.hmrc.hmrcfrontend.config.ServiceNavigationConfig
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
@@ -33,7 +34,8 @@ class HelpController @Inject() (
   mcc: MessagesControllerComponents,
   termsAndConditionsPage: TermsAndConditionsPage,
   onlineServicesTermsPage: OnlineServicesTermsPage,
-  cookiesPage: CookiesPage
+  cookiesPage: CookiesPage,
+  serviceNavigationConfig: ServiceNavigationConfig
 )(using ExecutionContext)
     extends FrontendController(mcc)
     with I18nSupport {
@@ -52,9 +54,9 @@ class HelpController @Inject() (
     Ok(termsAndConditionsPage())
   }
 
-  val cookies: Action[AnyContent] = Action {
+  val cookies: Action[AnyContent] = Action { implicit request =>
     Redirect(
-      appConfig.cookieSettingsUrl,
+      serviceNavigationConfig.propagateViaQueryParam(appConfig.cookieSettingsUrl),
       MOVED_PERMANENTLY
     )
   }

--- a/app/uk/gov/hmrc/helpfrontend/views/CookiesPage.scala.html
+++ b/app/uk/gov/hmrc/helpfrontend/views/CookiesPage.scala.html
@@ -18,8 +18,9 @@
 @import uk.gov.hmrc.helpfrontend.views.html.{CookiesTable, Layout}
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcNewTabLinkHelper
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.newtablinkhelper.NewTabLinkHelper
+@import uk.gov.hmrc.hmrcfrontend.config.ServiceNavigationConfig
 
-@this(layout: Layout, newTabLinkHelper: HmrcNewTabLinkHelper, cookiesTable: CookiesTable)
+@this(layout: Layout, newTabLinkHelper: HmrcNewTabLinkHelper, cookiesTable: CookiesTable, serviceNavigationConfig: ServiceNavigationConfig)
 
 @()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 @surveyLink = {
@@ -149,8 +150,9 @@
     <p class="govuk-body" id="cookies-pega-paragraph-2">@messages("help.cookies.how_used.pega.info.2")</p>
     <p class="govuk-body" id="cookies-pega-more-info">
       @newTabLinkHelper(NewTabLinkHelper(
-        href = Some(messages("help.cookies.how_used.pega.link.url")),
-        text = messages("help.cookies.how_used.pega.link.text")
+        href = Some(serviceNavigationConfig.propagateViaQueryParam(messages("help.cookies.how_used.pega.link.url"))),
+        text = messages("help.cookies.how_used.pega.link.text"),
+        classList = Some("link-to-pega-cookie-details")
       ))@messages("general.fullstop")
     </p>
 
@@ -158,8 +160,9 @@
   <p class="govuk-body" id="cookies-tracking-consent-settings-paragraph">
     @messages("help.cookies.settings.info")
     @newTabLinkHelper(NewTabLinkHelper(
-      href = Some(messages("help.cookies.settings.tracking_consent.url")),
-      text = messages("help.cookies.settings.tracking_consent.text")
+      href = Some(serviceNavigationConfig.propagateViaQueryParam(messages("help.cookies.settings.tracking_consent.url"))),
+      text = messages("help.cookies.settings.tracking_consent.text"),
+      classList = Some("link-to-cookie-settings")
     ))@messages("general.fullstop")
   </p>
 }

--- a/app/uk/gov/hmrc/helpfrontend/views/TermsAndConditionsPage.scala.html
+++ b/app/uk/gov/hmrc/helpfrontend/views/TermsAndConditionsPage.scala.html
@@ -19,12 +19,13 @@
 @import uk.gov.hmrc.helpfrontend.views.html.Layout
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcNewTabLinkHelper
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.newtablinkhelper.NewTabLinkHelper
+@import uk.gov.hmrc.hmrcfrontend.config.ServiceNavigationConfig
 
-@this(layout: Layout, hmrcNewTabLinkHelper: HmrcNewTabLinkHelper)
+@this(layout: Layout, hmrcNewTabLinkHelper: HmrcNewTabLinkHelper, serviceNavigationConfig: ServiceNavigationConfig)
 
 @()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
 @* Privacy policy is no longer part of this service, but is served via a redirect in MDTP frontend routes *@
-@privacyLink = { <a class="govuk-link" href="@{routes.HelpController.index.url}/privacy">@messages("help.links.privacy_policy.text.lower_case")</a> }
+@privacyLink = { <a id="link-to-privacy-policy" class="govuk-link" href="@{serviceNavigationConfig.propagateViaQueryParam(routes.HelpController.index.url + "/privacy")}">@messages("help.links.privacy_policy.text.lower_case")</a> }
 @layout(pageTitle = Some(messages("help.terms_and_conditions.title"))) {
  <h1 class="govuk-heading-xl">@messages("help.terms_and_conditions.heading")</h1>
  <h2 class="govuk-heading-l" id="disclaimer">@messages("help.terms_and_conditions.disclaimer.heading")</h2>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -57,3 +57,6 @@ urls {
 }
 
 play-frontend-hmrc.useRebrand = "true"
+
+play.modules.disabled += "uk.gov.hmrc.hmrcfrontend.config.DefaultServiceNavigationConfigModule"
+play.modules.enabled += "uk.gov.hmrc.hmrcfrontend.config.ServiceNavigationCanBeControlledByQueryParamModule"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object AppDependencies {
 
   private val bootstrapVersion = "10.6.0"
-  private val frontendVersion  = "12.31.0"
+  private val frontendVersion  = "12.32.1"
   private val playVersion      = "play-30"
 
   val compile = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,7 +2,7 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapVersion = "10.6.0"
+  private val bootstrapVersion = "10.7.0"
   private val frontendVersion  = "12.32.1"
   private val playVersion      = "play-30"
 
@@ -14,7 +14,7 @@ object AppDependencies {
   val test = Seq(
     "uk.gov.hmrc"         %% s"bootstrap-test-$playVersion" % bootstrapVersion % Test,
     "org.scalatestplus"   %% "mockito-3-4"                  % "3.2.10.0"       % Test,
-    "org.jsoup"            % "jsoup"                        % "1.13.1"         % Test,
-    "com.vladsch.flexmark" % "flexmark-all"                 % "0.62.2"         % Test
+    "org.jsoup"            % "jsoup"                        % "1.22.2"         % Test,
+    "com.vladsch.flexmark" % "flexmark-all"                 % "0.64.8"         % Test
   )
 }

--- a/test/unit/controllers/HelpControllerSpec.scala
+++ b/test/unit/controllers/HelpControllerSpec.scala
@@ -17,6 +17,7 @@
 package unit.controllers
 
 import org.jsoup.Jsoup
+import org.scalatest.OptionValues
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
@@ -33,7 +34,12 @@ import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 
-class HelpControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with JsoupHelpers {
+class HelpControllerSpec
+    extends AnyWordSpec
+    with Matchers
+    with GuiceOneAppPerSuite
+    with JsoupHelpers
+    with OptionValues {
   private val fakeRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
 
   private val fakeRequestWithLang: FakeRequest[AnyContentAsEmpty.type] =
@@ -69,6 +75,84 @@ class HelpControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSu
       val headers = content.select("h1")
       headers.size mustBe 1
       headers.first.text mustBe "Cookies"
+    }
+
+    "have a link to pega cookie details" in {
+      val result = route(app, FakeRequest("GET", "/help/cookie-details")).value
+
+      val linkToPegaCookieDetails = Option(
+        Jsoup.parse(contentAsString(result)).getElementsByClass("link-to-pega-cookie-details").first()
+      ).map(_.attr("href"))
+
+      linkToPegaCookieDetails mustBe Some("https://account.hmrc.gov.uk/debt/cookies")
+    }
+
+    "propagate use of service navigation to link to pega cookie details" in {
+      val result = route(app, FakeRequest("GET", "/help/cookie-details?useServiceNavigation")).value
+
+      val linkToPegaCookieDetails = Option(
+        Jsoup.parse(contentAsString(result)).getElementsByClass("link-to-pega-cookie-details").first()
+      ).map(_.attr("href"))
+
+      linkToPegaCookieDetails mustBe Some("https://account.hmrc.gov.uk/debt/cookies?useServiceNavigation")
+    }
+
+    "have a link to cookie settings" in {
+      val result = route(app, FakeRequest("GET", "/help/cookie-details")).value
+
+      val linkToPegaCookieDetails = Option(
+        Jsoup.parse(contentAsString(result)).getElementsByClass("link-to-cookie-settings").first()
+      ).map(_.attr("href"))
+
+      linkToPegaCookieDetails mustBe Some("/tracking-consent/cookie-settings")
+    }
+
+    "propagate use of service navigation to link to cookie settings" in {
+      val result = route(app, FakeRequest("GET", "/help/cookie-details?useServiceNavigation")).value
+
+      val linkToPegaCookieDetails = Option(
+        Jsoup.parse(contentAsString(result)).getElementsByClass("link-to-cookie-settings").first()
+      ).map(_.attr("href"))
+
+      linkToPegaCookieDetails mustBe Some("/tracking-consent/cookie-settings?useServiceNavigation")
+    }
+  }
+
+  "GET /help/cookies" should {
+    "redirect to cookie settings page in tracking consent" in {
+      val result = route(app, FakeRequest("GET", "/help/cookies")).value
+      status(result) mustBe MOVED_PERMANENTLY
+      redirectLocation(result) mustBe Some("http://localhost:12345/tracking-consent/cookie-settings")
+    }
+
+    "propagate use of service navigation across the redirect" in {
+      val result = route(app, FakeRequest("GET", "/help/cookies?useServiceNavigation")).value
+      status(result) mustBe MOVED_PERMANENTLY
+      redirectLocation(result) mustBe Some(
+        "http://localhost:12345/tracking-consent/cookie-settings?useServiceNavigation"
+      )
+    }
+  }
+
+  "GET /terms-and-conditions" should {
+    "have a link to privacy policy" in {
+      val result = route(app, FakeRequest("GET", "/help/terms-and-conditions")).value
+
+      val linkToPrivacyPolicy = Option(
+        Jsoup.parse(contentAsString(result)).getElementById("link-to-privacy-policy")
+      ).map(_.attr("href"))
+
+      linkToPrivacyPolicy mustBe Some("/help/privacy")
+    }
+
+    "propagate use of service navigation to link to privacy policy" in {
+      val result = route(app, FakeRequest("GET", "/help/terms-and-conditions?useServiceNavigation")).value
+
+      val linkToPrivacyPolicy = Option(
+        Jsoup.parse(contentAsString(result)).getElementById("link-to-privacy-policy")
+      ).map(_.attr("href"))
+
+      linkToPrivacyPolicy mustBe Some("/help/privacy?useServiceNavigation")
     }
   }
 


### PR DESCRIPTION
I did realise after this:
- privacy policy link is a redirect so not really needing ?useServiceNavigation - but kept for consistency because we add to footer link too
- pega cookie details page is actually already using service nav all the time so not really doing much to add it -but have done this in case they decide they want to start using it - will presume that's probably a safe boundary to ignore - in the sense that the alternative is that we stop linking to stuff because it brings things into accessibility scope - and that itself seems like a bit of an accessibility issue